### PR TITLE
Fix Zeitwerk::NameError on RecordLoader

### DIFF
--- a/app/graphql/loaders/record_loader.rb
+++ b/app/graphql/loaders/record_loader.rb
@@ -1,10 +1,12 @@
-class RecordLoader < GraphQL::Batch::Loader
-  def initialize(model)
-    @model = model
-  end
+module Loaders
+  class RecordLoader < GraphQL::Batch::Loader
+    def initialize(model)
+      @model = model
+    end
 
-  def perform(ids)
-    @model.where(id: ids).each { |record| fulfill(record.id, record) }
-    ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+    def perform(ids)
+      @model.where(id: ids).each { |record| fulfill(record.id, record) }
+      ids.each { |id| fulfill(id, nil) unless fulfilled?(id) }
+    end
   end
 end

--- a/app/graphql/types/category_type.rb
+++ b/app/graphql/types/category_type.rb
@@ -15,15 +15,15 @@ module Types
     field :parent_category, CategoryType, null: true
 
     def latest_post
-      RecordLoader.for(Post).load(object.latest_post_id)
+      Loaders::RecordLoader.for(Post).load(object.latest_post_id)
     end
 
     def latest_topic
-      RecordLoader.for(Topic).load(object.latest_topic_id)
+      Loaders::RecordLoader.for(Topic).load(object.latest_topic_id)
     end
 
     def parent_category
-      RecordLoader.for(Category).load(object.parent_category_id)
+      Loaders::RecordLoader.for(Category).load(object.parent_category_id)
     end
   end
 end

--- a/app/graphql/types/post_type.rb
+++ b/app/graphql/types/post_type.rb
@@ -27,7 +27,7 @@ module Types
     end
 
     def topic
-      RecordLoader.for(Topic).load(object.topic_id)
+      Loaders::RecordLoader.for(Topic).load(object.topic_id)
     end
   end
 end

--- a/app/graphql/types/topic_type.rb
+++ b/app/graphql/types/topic_type.rb
@@ -15,7 +15,7 @@ module Types
     field :category, CategoryType, null: false
 
     def category
-      RecordLoader.for(Category).load(object.category_id)
+      Loaders::RecordLoader.for(Category).load(object.category_id)
     end
   end
 end


### PR DESCRIPTION
Fixes ```/var/www/discourse/vendor/bundle/ruby/2.7.0/gems/zeitwerk-2.4.2/lib/zeitwerk/loader/callbacks.rb:18:in `on_file_autoloaded': expected file /var/www/discourse/plugins/discourse-graphql/app/graphql/loaders/record_loader.rb to define constant Loaders::RecordLoader, but didn't (Zeitwerk::NameError)```.

(https://meta.discourse.org/t/unofficial-discourse-graphql-api-plugin/158955/5)